### PR TITLE
Only redirect when on New Tab page

### DIFF
--- a/redirect.js
+++ b/redirect.js
@@ -13,7 +13,9 @@ function init(){
 	    return;
 	} else {
 	    chrome.tabs.getCurrent(function(t) {
-		r(t.id, url);
+	        if (t.url == "chrome://newtab/") {
+	            r(t.id, url);
+	        }
 	    });
 	}
     });


### PR DESCRIPTION
When Chrome takes some time executing our code, during which the the
user replaces the page via bookmarks or address bar, then we shouldn't
redirect.
