### PR TITLE
"Dark Theme" CSS (Incomplete)

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -44,9 +44,9 @@ blockquote {
 
 body {
   min-width:560px;
-  color: rgba(10,10,10,0.7);
+  color: rgba(232,230,227,0.7);
   font-family: sans-serif;
-  background-color: rgba(250,250,250,1);
+  background-color: rgb(24,26,27);
   overflow-x:auto;
 }
 
@@ -56,17 +56,17 @@ h2 {
 }
 
 a {
-  color: rgba(0,0,255,0.7);
+  color: rgba(105,151,244,0.7);
   text-decoration: none;
 }
 
 a:hover {
-  color: rgba(0,0,255,0.8);
+  #color: rgba(0,0,255,0.8);
   text-decoration: underline;
 }
 
 a.plain {
-color: rgba(10,10,10,0.7);
+#color: rgba(10,10,10,0.7);
 text-decoration: none;
 }
 
@@ -77,7 +77,7 @@ a[rel=publisher] {
   float:right;
   text-decoration:none;
   display:inline-block;
-  color:#333;
+  #color:#333;
   text-align: center;
   font:13px/16px arial,sans-serif;
   white-space:nowrap;
@@ -160,7 +160,7 @@ div.app-icon {
 
 .app-logo a,
 div.app-icon a {
-    color: rgba(0,0,0,0.7);
+    #color: rgba(0,0,0,0.7);
     text-decoration: none;
 }
 
@@ -251,7 +251,7 @@ div.bookmarks-container.populated {
 div.bookmarks-container .bookmark {
     display: inline-block;
     border-radius: 2px;
-    background-color: rgba(255,255,255,0.4);
+    background-color: rgb(41, 42, 45);
     padding: 4px 3px 2px 3px;
     -webkit-box-shadow: 1px 1px 2px 0 rgba(50, 50, 50, 0.66);
 }
@@ -260,7 +260,7 @@ div.app-header {
     position: fixed;
     top: 0;
     height: 30px;
-    background-color: rgba(186,211,218,0.8);
+    background-color: rgb(41, 42, 45);
     width:100%;
     z-index: 10000;
 }
@@ -297,7 +297,7 @@ span.webstore a i {
 
 #top-sites {
     position: fixed;
-    background: rgba(186,211,218,0.95);
+    background: rgb(41, 42, 45);
     -webkit-transition-duration: 0.3s;
     border-radius: 0 5px 5px 0;
     width:15.4em;
@@ -374,7 +374,7 @@ span#app-prefs {
     position:fixed;
     bottom:10px;
     right:10px;
-    background-color: rgba(255, 255, 255, 0.9);
+    background-color: rgb(41, 42, 45);
     padding:0;
     border-radius: 2px;
     margin:3px;
@@ -397,7 +397,7 @@ span#app-prefs i {
     right: 0;
     bottom: 0;
     left: 0;
-    background-color: rgba(0,0,0,0.6);
+    background-color: rgba(0,0,0,0.2);
     pointer-events: auto;
     -webkit-transition: all 500ms ease-out;
     -webtkit-transition-property: right, opacity;
@@ -420,7 +420,7 @@ span#app-prefs i {
     margin-right:auto;
     padding:15px 20px 30px 20px;
     border-radius: 7px;
-    background: rgba(255,255,255,0.95);
+    background: rgb(41, 42, 45);
     -webkit-box-shadow: 3px 3px 5px 0 rgba(50, 50, 50, 0.66);
 }
 
@@ -435,7 +435,7 @@ span#app-prefs i {
     -moz-box-align: center;
     align-items: center;
     backface-visibility: hidden;
-    background-color: rgb(232, 91, 70);
+    background-color: rgba(232, 91, 70, 0.2);
     border-radius: 9999px;
     border: medium none;
     box-sizing: border-box;

--- a/css/options.css
+++ b/css/options.css
@@ -6,11 +6,11 @@ footer {
     margin-top: 0;
     margin-left: auto;
     margin-right: auto;
-    height: 40px;
+    height: 30px;
     padding: 0 2px 5px 8px;
     max-width: 99%;
     width: 100%;
-    background: #FFFFFF;
+    background: rgb(41, 42, 45);
 }
 
 body.options-page {
@@ -48,16 +48,16 @@ ul.options-tabs li {
 }
 
 ul.options-tabs li:hover {
-    background-color:  rgba(186,211,218,0.8);
+    background-color: rgb(41, 42, 45);
     cursor: pointer;
 }
 
 ul.options-tabs li.selected {
-    background-color:  rgba(186,211,218,0.8);
+    background-color: rgb(41, 42, 45);
 }
 
 ul.options-tabs li a {
-    color: black;
+    #color: black;
     cursor: auto;
     text-decoration: none;
     display:block;
@@ -71,7 +71,7 @@ ul.options-tabs li.selected a {
 
 ul.options-tabs li:not(.selected) a:hover {
     cursor: pointer;
-    font-weight: 800;
+    #font-weight: 800;
 }
 
 .column2 {
@@ -101,7 +101,7 @@ h4 { margin: 4px 0; }
     padding: 14px;
     font-size: 1.3em;
     border: 2px solid #7c82bf;
-    background-color: rgba(180, 255, 165, 0.8);
+    background-color: rgb(41, 42, 45);
     border-radius: 7px;
     font-weight: 800;
 }


### PR DESCRIPTION
To get the conversation started on #175, these are some minimal changes I've made to the CSS to get everything looking "nice", but in a dark theme (based on the colour scheme of other well-accepted dark themes).

![image](https://user-images.githubusercontent.com/2285037/95079523-1f796f80-06ed-11eb-93a9-9f4dcd3db7c6.png)

![image](https://user-images.githubusercontent.com/2285037/95079559-2bfdc800-06ed-11eb-9c95-1d96ec6c79c8.png)


I realize that the more difficult job is to make this configurable / togglable, so my apologies for not delving into that myself.

The *most important* aspect of this change is that when opening a new tab (in the few milliseconds before the redirect), the user does not get greeted with a flash of white before then transitioning to a dark destination site.

![image](https://user-images.githubusercontent.com/2285037/95079754-6ff0cd00-06ed-11eb-845b-a770765aea1c.png)

If you wanted to be real smooth, you could actually "remember" the body background-colour of the configured redirect site, and set that as the background, but I have no thoughts on we might implement that. Just a thought.

All the best,