### PR TITLE
Switch to manifest v3 since v2 is deprecated

### DIFF
--- a/examples/empty/manifest.txt
+++ b/examples/empty/manifest.txt
@@ -4,5 +4,5 @@
   "version": "1.0",
   "incognito": "split",
   "chrome_url_overrides": { "newtab": "empty.html" },
-  "manifest_version": 2
+  "manifest_version": 3
 }


### PR DESCRIPTION
Some useful links:
https://developer.chrome.com/docs/extensions/mv3/intro/
https://developer.chrome.com/docs/extensions/mv3/mv3-migration/

Since this extension is pretty barebones, I don't think there is anything to change other than the declared manifest version.  I tried to add it to Chrome earlier today as-is, got the error about V2, changed it to 3 and added it again, this time without an error.