### PR TITLE
Added new host_permissions to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,6 +13,7 @@
     "newtab": "main.html"
   },
   "permissions": ["storage", "chrome://favicon/"],
+  "host_permissions": ["file:///", "file://", ":///*"],
   "optional_permissions": ["tabs", "topSites", "management", "bookmarks"],
   "icons": {
     "200": "images/icon200.png",


### PR DESCRIPTION
Added host_permissions to the manifest to fix local filesystem permission issue setting that was removed in Chrome v118. Resolves issue #218 

https://github.com/jimschubert/NewTab-Redirect/issues/218