### PR TITLE
Fix #235: redirect URL ignored after local settings copy is lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Historical release notes prior to this file live in [changes.txt](changes.txt).
+
+## [Unreleased]
+
+## [3.2.0] - 2026-07-25
+
+### Fixed
+
+- Redirect URL ignored (the New Tab Redirect apps page shown instead) when the
+  local copy of settings was lost while the synced copy survived. The new tab
+  page now falls back to `storage.sync` and repairs `storage.local`, so the
+  next tab takes the fast path again.
+  ([upstream #235](https://github.com/jimschubert/NewTab-Redirect/issues/235))
+- Clicking **Save** without changing the URL could not repair a broken state:
+  options saved only to `storage.sync` and the background mirror relies on
+  `storage.onChanged`, which Chrome does not fire for same-value writes.
+  Options now always write `storage.local` (what the new tab page reads)
+  directly, plus `storage.sync` when the sync option is enabled.
+- Crash in the background service worker's initial setup (`JSON.parse` called
+  on an object), which could leave a fresh install without default settings.

--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,12 @@
+v3.2.0
+ * Fix bug where the redirect URL was ignored (New Tab Redirect apps page shown
+   instead) after the local copy of settings was lost. The new tab page now
+   falls back to the synced URL and repairs local storage. (#235)
+ * Fix bug where clicking Save without changing the URL could not repair a
+   broken state (Chrome fires no storage change event for same-value writes).
+   Options now always save to local storage directly, plus sync when enabled.
+ * Fix crash in initial setup (JSON.parse called on an object) that could leave
+   a fresh install without defaults.
 v3.1.6
  * Migrate to Manifest v3
  * Contribution from Talesh, fixing file:// loading

--- a/js/background.js
+++ b/js/background.js
@@ -23,8 +23,10 @@ async function saveInitial() {
     var options = {};
     var arr = await chrome.storage.local.get('syncOptions');
     if (Object.keys(arr).length) {
-        log('Found options on localStorage');
-        options = JSON.parse(arr);
+        log('Found existing options in storage');
+        // storage.local.get resolves to a plain object; passing it through
+        // JSON.parse threw a SyntaxError and aborted initial setup entirely.
+        options = arr;
     }
 
     // by default, initial installs won't sync options

--- a/js/options_controller.js
+++ b/js/options_controller.js
@@ -32,10 +32,18 @@
             }
 
             $scope.save = function () {
-                var promise = Storage[$scope.sync ? 'saveSync' : 'saveLocal']({
+                var options = {
                     'url': $scope.url,
                     'always-tab-update': $scope.alwaysTabUpdate
-                });
+                };
+                // The new tab page reads storage.local, so always write there
+                // first; sync is the roaming copy, not the source of truth.
+                // Relying on the background onChanged mirror breaks on
+                // same-value saves because Chrome suppresses the event. (#235)
+                var promise = Storage.saveLocal(options)
+                    .then(function () {
+                        return $scope.sync ? Storage.saveSync(options) : null;
+                    });
                 promise.then(function () {
                     $scope.show_saved = true;
                     $timeout(function () {

--- a/js/redirect.js
+++ b/js/redirect.js
@@ -1,27 +1,46 @@
 /*global chrome,document,window */
 (function init(angular) {
     "use strict";
+
+    function redirect(url, items) {
+        url = (0 !== url.indexOf("about:") && 0 !== url.indexOf("data:") && -1 === url.indexOf("://")) ? ("http://" + url) : url;
+        if (/^http[s]?:/i.test(url) && items["always-tab-update"] !== true) {
+            document.location.href = url;
+        } else {
+            chrome.tabs.getCurrent(function (tab) {
+                // a keen user may open the extension's background page and set:
+                // chrome.storage.local.set({'tab.selected': false});
+                var selected = items["tab.selected"] === undefined ? true : (items["tab.selected"] == "true");
+                chrome.tabs.update(tab.id, {
+                    "url": url,
+                    "highlighted": selected
+                });
+            });
+        }
+    }
+
     try {
         chrome.storage.local.get(["url", "tab.selected", "always-tab-update"], function (items) {
-            var url = items.url;
-            if (url) {
-                url = (0 !== url.indexOf("about:") && 0 !== url.indexOf("data:") && -1 === url.indexOf("://")) ? ("http://" + url) : url;
-                if (/^http[s]?:/i.test(url) && items["always-tab-update"] !== true) {
-                    document.location.href = url;
-                } else {
-                    chrome.tabs.getCurrent(function (tab) {
-                        // a keen user may open the extension's background page and set:
-                        // chrome.storage.local.set({'tab.selected': false});
-                        var selected = items["tab.selected"] === undefined ? true : (items["tab.selected"] == "true");
-                        chrome.tabs.update(tab.id, {
-                            "url": url,
-                            "highlighted": selected
-                        });
-                    });
-                }
-            } else {
-                angular.resumeBootstrap();
+            if (items.url) {
+                return redirect(items.url, items);
             }
+
+            // The local copy of the url can be lost (interrupted writes, missed
+            // service worker events, reinstalls) while the synced copy survives.
+            // Chrome doesn't fire onChanged for same-value writes, so the
+            // background mirror can never repair this state on its own. Fall
+            // back to sync and heal local so the next tab takes the fast path. (#235)
+            chrome.storage.sync.get(["url", "always-tab-update"], function (synced) {
+                if (chrome.runtime.lastError || !synced || !synced.url) {
+                    return angular.resumeBootstrap();
+                }
+                var repaired = { "url": synced.url };
+                if (synced["always-tab-update"] !== undefined) {
+                    repaired["always-tab-update"] = synced["always-tab-update"];
+                }
+                chrome.storage.local.set(repaired);
+                redirect(synced.url, angular.extend({}, items, repaired));
+            });
         });
     } catch(e){
         // If anything goes wrong with the redirection logic, fail to custom apps page.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "New Tab Redirect",
   "short_name": "NTR!",
   "description": "Allows a user to provide the URL of the page that loads in a new tab.",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "background": {
     "service_worker" : "js/background.js"
   },


### PR DESCRIPTION
Hi Jim - I dug into #235 after hitting it myself and found the root cause, figured I'd send the fix along.

## What's happening

The new tab page (`js/redirect.js`) only reads `storage.local`. The options page, when it's in sync mode, only writes `storage.sync`. The bridge is background.js mirroring sync->local on `storage.onChanged` - but Chrome doesn't fire `onChanged` when a write doesn't change the value. So once `local.url` goes missing (interrupted write, missed service worker event, reinstall - doesn't much matter how), the extension is stuck: options still *displays* the right URL from sync, but clicking Save re-writes the same value, no event fires, local never gets repaired, and every new tab falls through to the apps page. That's also exactly why the workaround people found (save a different URL, then change it back) works - it forces a real change event.

## The fix

- `redirect.js`: if `local.url` is empty, fall back to `sync.url` and write it back to local. Makes the broken state self-healing no matter how it happened.
- `options_controller.js`: Save always writes `storage.local` (what the new tab page actually reads) and additionally `storage.sync` when sync is on. Same-value saves can now repair things directly instead of depending on a suppressed event.
- `background.js`: `saveInitial` was calling `JSON.parse` on the object that `storage.local.get` resolves to, which throws and aborts initial setup whenever prior options exist.

## Verification

I built a Playwright harness that loads the unpacked extension and reproduces the broken state properly (seed `sync.url`, let the mirror settle, then remove `local.url` via a local-namespace change so the mirror can't heal it - naively writing sync in the test fires the mirror and hides the bug). On current master that repro shows the exact reported symptoms: new tab lands on the apps page, options shows the right URL, same-value Save does nothing. With this patch all five scenarios pass, including a regression check on the normal local-mode path. Happy to contribute the harness in a follow-up if you want it.

Heads up that this branch also bumps the version to 3.2.0 and adds a CHANGELOG.md - happy to drop either if you'd rather handle versioning yourself.

Fixes #235